### PR TITLE
Node fallback

### DIFF
--- a/mita/tests/unit/test_util.py
+++ b/mita/tests/unit/test_util.py
@@ -89,6 +89,10 @@ class TestOfflineNode(object):
         msg = BecauseNodeIsOffline % 'centos6'
         assert util.from_offline_node(msg) == 'centos6'
 
+    def test_matches_a_fallback(self):
+        msg = BecauseNodeIsOffline % '10.0.0.0_centos6_huge'
+        assert util.from_offline_node(msg) == 'centos6'
+
 
 class TestFromOfflineNodeLabel(object):
 

--- a/mita/util.py
+++ b/mita/util.py
@@ -21,10 +21,24 @@ def node_state_map():
 NodeState = node_state_map()
 
 
-def get_key(_dict, key, fallback=None):
+def get_key(_dict, key, fallback=True):
+    """
+    This helper is always used to check for a name (key) in configured nodes
+    (_dict). The fallback should is a boolean that should be lenient and try to
+    see if there is anything that will match.
+
+    This may be because a name can be like `10.0.0.1__name__huge` but the
+    configuration only has something for `name`. In which case it should try to
+    match that key and return it.
+    """
+    if not key:
+        return None
     if key in _dict:
         return key
-    return fallback or None
+    if fallback:
+        for name in _dict.keys():
+            if name in key:
+                return name
 
 # TODO: all these need proper logging
 # Stuck Queue Processors


### PR DESCRIPTION
If the key (name) is not present we will check for anything that matches. Adds a test to verify this behavior