### PR TITLE
check the jenkins api to see if a node is idle before removing it

### DIFF
--- a/mita/async.py
+++ b/mita/async.py
@@ -69,10 +69,17 @@ def check_idling():
         # check if they are idle, and if so, ping the mita API so that it can handle
         # proper removal of the node if it needs to
         for n in mita_nodes:
-            uuid = n['name'].split('__')[-1]
-            node_endpoint = get_mita_api('nodes', uuid, 'idle')
-            requests.post(node_endpoint)
-
+            node_info = conn.get_node_info(n['name'])
+            logger.info('node info for %s: %s' % (n['name'], node_info))
+            if node_info.get('idle'):
+                logging.info("found an idle node: %s" % n['name'])
+                uuid = n['name'].split('__')[-1]
+                node_endpoint = get_mita_api('nodes', uuid, 'idle')
+                requests.post(node_endpoint)
+            else:
+                logger.info('%s is not idle, reset node.idle_since' % n['name'])
+                node_endpoint = get_mita_api('nodes', uuid, 'active')
+                requests.post(node_endpoint)
     else:
         logger.info('no Jenkins nodes added by this service where found')
 

--- a/mita/controllers/nodes.py
+++ b/mita/controllers/nodes.py
@@ -24,6 +24,16 @@ class NodeController(object):
             abort(404)
 
     @expose('json')
+    def active(self):
+        """
+        Mark the node as active by setting idle_since to None.
+        """
+        if not self.node:
+            abort(404, 'could not find UUID: %s' % self.identifier)
+        logger.info("Marking %s as active." % self.node.identifier)
+        self.node.idle_since = None
+
+    @expose('json')
     def idle(self):
         """
         perform a check on the status of the current node, verifying how long
@@ -44,6 +54,7 @@ class NodeController(object):
             difference = now - self.node.idle_since
             if difference.seconds > 600:  # 10 minutes
                 # we need to terminate this couch potato
+                logger.info("Destroying node: %s" % self.node.cloud_name)
                 provider.destroy_node(name=self.node.cloud_name)
                 # FIXMEEEEEEEE
                 jenkins_url = conf.jenkins['url']

--- a/mita/tests/functional/controllers/test_nodes.py
+++ b/mita/tests/functional/controllers/test_nodes.py
@@ -56,3 +56,25 @@ class TestNodesController(object):
         node = Node.get(1)
         assert node.idle_since is not None
 
+    def test_make_node_active(self, session, monkeypatch):
+        monkeypatch.setattr('mita.providers.openstack.create_node', Mock())
+        session.app.post_json(
+            '/api/nodes/',
+            params={
+                'name': 'wheezy-slave',
+                'provider': 'openstack',
+                'keyname': 'ci-key',
+                'image_name': 'beefy-wheezy',
+                'size': '3xlarge',
+                'script': '#!/bin/bash echo hello world! %s',
+                'labels': ['wheezy', 'amd64'],
+            }
+        )
+        node = Node.get(1)
+        session.app.post('/api/nodes/%s/idle' % node.identifier)
+        node = Node.get(1)
+        assert node.idle_since is not None
+        session.app.post('/api/nodes/%s/active' % node.identifier)
+        node = Node.get(1)
+        assert node.idle_since is None
+


### PR DESCRIPTION
This also adds in a endpoint at api/nodes/<uuid>/active that the
check_idling async task will call to mark a node as active.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>