### PR TITLE
properly remove slaves from jenkins when an instance is destroyed

### DIFF
--- a/mita/controllers/nodes.py
+++ b/mita/controllers/nodes.py
@@ -67,8 +67,8 @@ class NodeController(object):
                 jenkins_user = conf.jenkins['user']
                 jenkins_token = conf.jenkins['token']
                 conn = jenkins.Jenkins(jenkins_url, jenkins_user, jenkins_token)
-                # FIXME: We need to see if this jenkins_node exists first
-                conn.delete_node(self.node.cloud_name)
+                logger.info("Deleting node in jenkins: %s" % self.node.jenkins_name)
+                conn.delete_node(self.node.jenkins_name)
                 # delete from our database
                 self.node.delete()
 

--- a/mita/controllers/nodes.py
+++ b/mita/controllers/nodes.py
@@ -67,8 +67,9 @@ class NodeController(object):
                 jenkins_user = conf.jenkins['user']
                 jenkins_token = conf.jenkins['token']
                 conn = jenkins.Jenkins(jenkins_url, jenkins_user, jenkins_token)
-                logger.info("Deleting node in jenkins: %s" % self.node.jenkins_name)
-                conn.delete_node(self.node.jenkins_name)
+                if conn.node_exists(self.node.jenkins_name):
+                    logger.info("Deleting node in jenkins: %s" % self.node.jenkins_name)
+                    conn.delete_node(self.node.jenkins_name)
                 # delete from our database
                 self.node.delete()
 

--- a/mita/models/nodes.py
+++ b/mita/models/nodes.py
@@ -3,6 +3,7 @@ from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.orm.exc import DetachedInstanceError
 from mita.models import Base
+from mita.util import get_jenkins_name
 
 
 class Node(Base):
@@ -42,6 +43,12 @@ class Node(Base):
     @property
     def cloud_name(self):
         return u'%s__%s' % (self.name, self.identifier)
+
+    @property
+    def jenkins_name(self):
+        if not hasattr(self, "_jenkins_name"):
+            self._jenkins_name = get_jenkins_name(self.identifier)
+        return self._jenkins_name
 
     @property
     def idle(self):

--- a/mita/util.py
+++ b/mita/util.py
@@ -1,3 +1,5 @@
+import jenkins
+
 from libcloud.compute import types
 from pecan import conf
 
@@ -198,3 +200,19 @@ def get_nodes():
         return conf['nodes'].to_dict()
     except AttributeError:
         return conf['nodes']
+
+
+def get_jenkins_name(uuid):
+    """
+    Given a node's identifier use the jenkins api to find a node name in jenkins
+    that includes that uuid and return it.
+    """
+    jenkins_url = conf.jenkins['url']
+    jenkins_user = conf.jenkins['user']
+    jenkins_token = conf.jenkins['token']
+    conn = jenkins.Jenkins(jenkins_url, jenkins_user, jenkins_token)
+    nodes = conn.get_nodes()
+    for node in nodes:
+        if uuid in node['name']:
+            return node['name']
+    return None


### PR DESCRIPTION
The cloud name of a jenkins slave and the name it uses in the jenkins UI are different. Make sure we're using the correct name when deleting the slave from jenkins.