### PR TITLE
do not use color output in production logs

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod.py.j2
@@ -44,12 +44,13 @@ logging = {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'color'
+            'formatter': 'simple'
         }
     },
     'formatters': {
         'simple': {
-            'format': ('%(asctime)s %(levelname)-5.5s [%(name)s]'
+            'format': ('%(asctime)s [%(levelname)-8s] [%(name)s]'
+%-8s
                        '[%(threadName)s] %(message)s')
         },
         'color': {


### PR DESCRIPTION
It is a (naive) attempt to prevent double lines in production logs. Even if it does not fix that problem it is still a good idea not to have ascii chars in prod logs