### PR TITLE
do not break when a node cannot be found

### DIFF
--- a/mita/util.py
+++ b/mita/util.py
@@ -1,5 +1,6 @@
 from xml.etree import ElementTree
 from libcloud.compute import types
+from jenkins import NotFoundException as JenkinsNotFoundException
 from pecan import conf
 import logging
 
@@ -238,7 +239,11 @@ def get_node_labels(node_name, _xml_configuration=None):
     right tag and extracting the labels from there.
     """
     conn = jenkins_connection()
-    xml_configuration = _xml_configuration or conn.get_node_config(node_name)
+    try:
+        xml_configuration = _xml_configuration or conn.get_node_config(node_name)
+    except JenkinsNotFoundException:
+        logging.warning('"%s" was not found in Jenkins', node_name)
+        return []
     xml_object = ElementTree.fromstring(xml_configuration)
     for node in xml_object:
         if node.tag == 'label':


### PR DESCRIPTION
This will prevent mita from breaking horribly when a node is not found in Jenkins.

Currently tests are broken because of the `connections.py` addition, will fix those next.