### PR TITLE
remove noisy logging in the check_idling task

### DIFF
--- a/mita/async.py
+++ b/mita/async.py
@@ -70,7 +70,6 @@ def check_idling():
         # proper removal of the node if it needs to
         for n in mita_nodes:
             node_info = conn.get_node_info(n['name'])
-            logger.info('node info for %s: %s' % (n['name'], node_info))
             uuid = n['name'].split('__')[-1]
             if node_info.get('idle'):
                 logging.info("found an idle node: %s" % n['name'])


### PR DESCRIPTION
This just prints way too much into the log and it's not very helpful for
normal situations.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>