### PR TITLE
include mita.tasks into the celery app in mita.async

### DIFF
--- a/mita/async.py
+++ b/mita/async.py
@@ -6,7 +6,7 @@ import jenkins
 import json
 import os
 import logging
-from mita import util, models, providers
+from mita import util
 logger = logging.getLogger(__name__)
 
 
@@ -20,7 +20,7 @@ def get_pecan_config():
 
 
 pecan.configuration.set_config(get_pecan_config(), overwrite=True)
-app = Celery('mita.async', broker='amqp://guest@localhost//')
+app = Celery('mita.async', broker='amqp://guest@localhost//', include=['mita.tasks'])
 
 
 def infer_labels(task_name):

--- a/mita/tasks.py
+++ b/mita/tasks.py
@@ -1,14 +1,10 @@
 import pecan
-from celery import Celery
+from celery import shared_task
 import logging
 from mita import util, models, providers
 logger = logging.getLogger(__name__)
 
-
-app = Celery('mita.async', broker='amqp://guest@localhost//')
-
-
-@app.task
+@shared_task
 def delete_node(node_id):
     node = models.Node.get(node_id)
     if not node:
@@ -23,10 +19,3 @@ def delete_node(node_id):
     util.delete_jenkins_node(node.jenkins_name)
     node.delete()
     models.commit()
-
-
-app.conf.update(
-    nodes=pecan.conf.nodes,
-    pecan_app=pecan.conf.server,
-    jenkins=pecan.conf.jenkins
-)


### PR DESCRIPTION
We need this so that the celery worker that runs mita.async can see the
tasks we put into mita.tasks.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>