### PR TITLE
change the 'unique' nodes to be ceph-ansible-pull-requests specific

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -67,14 +67,14 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'jessie', 'huge'],
         'provider': 'openstack'
     },
-    'trusty_small_unique': {
+    'ceph_ansible_pr_trusty': {
         'script': dedent("""#!/bin/bash
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+trusty+small+x86_64+unique&nodename=trusty_small_unique__%s" | bash
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=ceph_ansible_pr_trusty&nodename=ceph_ansible_pr_trusty__%s" | bash
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 14.04',
         'size': 'vps-ssd-1',
-        'labels': ['amd64', 'x86_64', 'trusty', 'small', 'unique'],
+        'labels': ['ceph_ansible_pr_trusty'],
         'provider': 'openstack',
         'storage': 10
     },
@@ -116,13 +116,13 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'centos6', 'huge'],
         'provider': 'openstack'
     },
-    'centos7_small_unique': {
+    'ceph_ansible_pr_centos7': {
         'script': dedent("""#!/bin/bash
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+centos7+small+x86_64+unique&nodename=centos7_small_unique__%s" | bash"""),
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=ceph_ansible_pr_centos7&nodename=ceph_ansible_pr_centos7__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 7',
         'size': 'vps-ssd-1',
-        'labels': ['amd64', 'x86_64', 'centos7', 'small', 'unique'],
+        'labels': ['ceph_ansible_pr_centos'],
         'provider': 'openstack',
         'storage': 10
     },


### PR DESCRIPTION
These nodes were always meant to be used exclusively by the
ceph-ansible-pull-requests job. Making the labels this specific will
ensure that no other jobs pick up these nodes, which has been trouble in
the past.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>